### PR TITLE
Extend buttonGroup Component

### DIFF
--- a/site/build.gradle.kts
+++ b/site/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     implementation(npm("file-loader", "6.0.0"))
 
     implementation(npm("react-syntax-highlighter", "12.2.1"))
-    implementation(npm("markdown-to-jsx", "6.11.1"))
+    implementation(npm("markdown-to-jsx", "6.11.4"))
 }
 
 kotlin.target {

--- a/site/build.gradle.kts
+++ b/site/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     implementation(npm("react-syntax-highlighter", "12.2.1"))
     implementation(npm("markdown-to-jsx", "6.11.4"))
+    testImplementation(npm("karma", "5.1.1"))
 }
 
 kotlin.target {

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/Docs.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/Docs.kt
@@ -107,7 +107,7 @@ class Docs : RComponent<RouteResultProps<RProps>, Docs.State>() {
     }
 
     internal object Pages {
-        var categories: List<Category> = listOf<Category>(
+        var categories: List<Category> = listOf(
 //            Category(
 //                "Getting started",
 //                "getting-started",

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/FunReference.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/FunReference.kt
@@ -53,6 +53,10 @@ internal data class FunReference(
             nullable: Boolean,
             default: String
         ) : this(name, type.simpleName!!, nullable, default)
+
+        companion object {
+            const val NULL = "null"
+        }
     }
 
     fun print(oneLine: Boolean): String {
@@ -72,7 +76,7 @@ internal data class FunReference(
             argStringBuilder.toString()
         }
 
-        val returnTypeString = returnType?.let { ": $it" }
+        val returnTypeString = ": ${(returnType ?: Unit::class.simpleName!!)}"
 
         return if (oneLine) {
             "fun $receiverString${kFunction.name}(${argsStrings.joinToString()})$returnTypeString"

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/Helper.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/Helper.kt
@@ -1,0 +1,20 @@
+package react.bootstrap.site.components.docs.components
+
+import react.RBuilder
+import react.bootstrap.components.button.ButtonGroup
+import react.bootstrap.components.button.Buttons
+import react.bootstrap.components.button.buttonGroup
+import react.bootstrap.site.components.docs.buildNestedName
+import react.bootstrap.site.components.docs.fixings.CodeExampleBuilder
+
+internal fun CodeExampleBuilder.importButtonsBuilder() {
+    import(buildNestedName(RBuilder::Buttons.name, "components", "button"))
+}
+
+internal fun CodeExampleBuilder.importButtonGroup() {
+    import(buildNestedName(ButtonGroup::class.simpleName!!, "components", "button"))
+}
+
+internal fun CodeExampleBuilder.importButtonGroupBuilder() {
+    import(buildNestedName(RBuilder::buttonGroup.name, "components", "button"))
+}

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/alerts/Reference.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/alerts/Reference.kt
@@ -35,6 +35,7 @@ internal class Reference : SectionComponent() {
     override val title: String = "Reference"
 
     override fun RBuilder.render() {
+        sectionTitle(section)
         subSectionTitle(alertName, section)
         p {
             +"Adds an alert component."
@@ -45,7 +46,7 @@ internal class Reference : SectionComponent() {
                 setOf(RBuilder::class.simpleName!!),
                 setOf(
                     FunReference.Argument("variant", Alert.Variants::class.nestedName),
-                    FunReference.Argument("classes", String::class, true, "null"),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
                     FunReference.Argument("block", "RHandler<${Alert.Props::class.nestedName}>")
                 ),
                 "ReactElement"
@@ -62,8 +63,8 @@ internal class Reference : SectionComponent() {
                 setOf(RBuilder::class.simpleName!!),
                 setOf(
                     FunReference.Argument("variant", Alert.Variants::class.nestedName),
-                    FunReference.Argument("fade", Boolean::class, true, "null"),
-                    FunReference.Argument("classes", String::class, true, "null"),
+                    FunReference.Argument("fade", Boolean::class, true, FunReference.Argument.NULL),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
                     FunReference.Argument("block", "RHandler<${Alert.DismissibleProps::class.nestedName}>")
                 ),
                 "ReactElement"
@@ -117,7 +118,7 @@ Custom `h1` which behaves the same but adds `${ClassNames.ALERT_HEADING.kt}` to 
                 RElementBuilder<Alert.Props>::h1,
                 setOf("${RElementBuilder::class.simpleName}<${Alert.Props::class.nestedName}>"),
                 setOf(
-                    FunReference.Argument("classes", String::class, true, "null"),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
                     FunReference.Argument("block", "RDOMHandler<${H1::class.simpleName}>")
                 ),
                 "ReactElement"
@@ -135,7 +136,7 @@ Custom `h2` which behaves the same but adds `${ClassNames.ALERT_HEADING.kt}` to 
                 RElementBuilder<Alert.Props>::h2,
                 setOf("${RElementBuilder::class.simpleName}<${Alert.Props::class.nestedName}>"),
                 setOf(
-                    FunReference.Argument("classes", String::class, true, "null"),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
                     FunReference.Argument("block", "RDOMHandler<${H2::class.simpleName}>")
                 ),
                 "ReactElement"
@@ -153,7 +154,7 @@ Custom `h3` which behaves the same but adds `${ClassNames.ALERT_HEADING.kt}` to 
                 RElementBuilder<Alert.Props>::h3,
                 setOf("${RElementBuilder::class.simpleName}<${Alert.Props::class.nestedName}>"),
                 setOf(
-                    FunReference.Argument("classes", String::class, true, "null"),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
                     FunReference.Argument("block", "RDOMHandler<${H3::class.simpleName}>")
                 ),
                 "ReactElement"
@@ -171,7 +172,7 @@ Custom `h4` which behaves the same but adds `${ClassNames.ALERT_HEADING.kt}` to 
                 RElementBuilder<Alert.Props>::h4,
                 setOf("${RElementBuilder::class.simpleName}<${Alert.Props::class.nestedName}>"),
                 setOf(
-                    FunReference.Argument("classes", String::class, true, "null"),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
                     FunReference.Argument("block", "RDOMHandler<${H4::class.simpleName}>")
                 ),
                 "ReactElement"
@@ -189,7 +190,7 @@ Custom `h5` which behaves the same but adds `${ClassNames.ALERT_HEADING.kt}` to 
                 RElementBuilder<Alert.Props>::h5,
                 setOf("${RElementBuilder::class.simpleName}<${Alert.Props::class.nestedName}>"),
                 setOf(
-                    FunReference.Argument("classes", String::class, true, "null"),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
                     FunReference.Argument("block", "RDOMHandler<${H5::class.simpleName}>")
                 ),
                 "ReactElement"
@@ -207,7 +208,7 @@ Custom `h6` which behaves the same but adds `${ClassNames.ALERT_HEADING.kt}` to 
                 RElementBuilder<Alert.Props>::h6,
                 setOf("${RElementBuilder::class.simpleName}<${Alert.Props::class.nestedName}>"),
                 setOf(
-                    FunReference.Argument("classes", String::class, true, "null"),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
                     FunReference.Argument("block", "RDOMHandler<${H6::class.simpleName}>")
                 ),
                 "ReactElement"

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/BasicExample.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/BasicExample.kt
@@ -3,7 +3,12 @@ package react.bootstrap.site.components.docs.components.buttongroup
 import react.RBuilder
 import react.bootstrap.components.button.Buttons
 import react.bootstrap.components.button.buttonGroup
+import react.bootstrap.site.components.docs.components.buttons.importButtonsBuilder
+import react.bootstrap.site.components.docs.components.buttons.solidButtonBuilderParents
+import react.bootstrap.site.components.docs.components.buttons.solidSecondaryFun
+import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.SectionComponent
+import react.bootstrap.site.components.docs.fixings.codeExample
 import react.bootstrap.site.components.docs.fixings.liveExample
 import react.bootstrap.site.external.Markdown
 
@@ -18,11 +23,24 @@ internal class BasicExample : SectionComponent() {
 Wrap a series of buttons in `${RBuilder::buttonGroup.name}`.
             """
         }
+        val leftMiddleRight = listOf("Left", "Middle", "Right")
         liveExample {
             buttonGroup {
-                Buttons.solid.secondary { +"Left" }
-                Buttons.solid.secondary { +"Middle" }
-                Buttons.solid.secondary { +"Right" }
+                leftMiddleRight.forEach {
+                    Buttons.solid.secondary { +it }
+                }
+            }
+        }
+        codeExample {
+            importButtonsBuilder()
+            import("components.button.${RBuilder::buttonGroup.name}")
+            ln { }
+            ktFun(RBuilder::buttonGroup) {
+                leftMiddleRight.forEach {
+                    ktFun(solidSecondaryFun, solidButtonBuilderParents, style = FunStyle.INLINE_BLOCK) {
+                        string(it)
+                    }
+                }
             }
         }
     }

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonGroup.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonGroup.kt
@@ -15,5 +15,6 @@ Group a series of buttons together on a single line with the button group, and s
         child(ButtonToolbar::class)
         child(Sizing::class)
         // Todo add Nesting when Dropdown component is done
+        child(VerticalVariation::class)
     }
 }

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonGroup.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonGroup.kt
@@ -16,5 +16,6 @@ Group a series of buttons together on a single line with the button group, and s
         child(Sizing::class)
         // Todo add Nesting when Dropdown component is done
         child(VerticalVariation::class)
+        child(Reference::class)
     }
 }

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonGroup.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonGroup.kt
@@ -12,5 +12,8 @@ Group a series of buttons together on a single line with the button group, and s
             """.trimIndent()
         }
         child(BasicExample::class)
+        child(ButtonToolbar::class)
+        child(Sizing::class)
+        // Todo add Nesting when Dropdown component is done
     }
 }

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonGroup.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonGroup.kt
@@ -8,7 +8,7 @@ internal class ButtonGroup : PageComponent() {
         pageTitle("Button group")
         pageLead {
             +"""
-Group a series of buttons together on a single line with the button group, and super-power them with JavaScript.
+Group a series of buttons together on a single line with the button group, and super-power them with Kotlin JavaScript.
             """.trimIndent()
         }
         child(BasicExample::class)

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonToolbar.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonToolbar.kt
@@ -5,9 +5,10 @@ import react.bootstrap.components.button.Buttons
 import react.bootstrap.components.button.buttonGroup
 import react.bootstrap.components.button.buttonToolbar
 import react.bootstrap.lib.ClassNames
-import react.bootstrap.site.components.docs.components.buttons.importButtonsBuilder
 import react.bootstrap.site.components.docs.components.buttons.solidButtonBuilderParents
 import react.bootstrap.site.components.docs.components.buttons.solidSecondaryFun
+import react.bootstrap.site.components.docs.components.importButtonGroupBuilder
+import react.bootstrap.site.components.docs.components.importButtonsBuilder
 import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.Quoted
 import react.bootstrap.site.components.docs.fixings.SectionComponent
@@ -46,7 +47,7 @@ out groups, buttons, and more.
         }
         codeExample {
             importButtonsBuilder()
-            import("components.button.${RBuilder::buttonGroup.name}")
+            importButtonGroupBuilder()
             import("components.button.${RBuilder::buttonToolbar.name}")
             ln { }
             ktFun(RBuilder::buttonToolbar, args = mapOf("label" to Quoted("Toolbar with button groups"))) {

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonToolbar.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/ButtonToolbar.kt
@@ -1,0 +1,85 @@
+package react.bootstrap.site.components.docs.components.buttongroup
+
+import react.RBuilder
+import react.bootstrap.components.button.Buttons
+import react.bootstrap.components.button.buttonGroup
+import react.bootstrap.components.button.buttonToolbar
+import react.bootstrap.lib.ClassNames
+import react.bootstrap.site.components.docs.components.buttons.importButtonsBuilder
+import react.bootstrap.site.components.docs.components.buttons.solidButtonBuilderParents
+import react.bootstrap.site.components.docs.components.buttons.solidSecondaryFun
+import react.bootstrap.site.components.docs.fixings.FunStyle
+import react.bootstrap.site.components.docs.fixings.Quoted
+import react.bootstrap.site.components.docs.fixings.SectionComponent
+import react.bootstrap.site.components.docs.fixings.codeExample
+import react.bootstrap.site.components.docs.fixings.liveExample
+import react.bootstrap.site.components.docs.kt
+import react.dom.p
+
+internal class ButtonToolbar : SectionComponent() {
+    override val title: String = "Button toolbar"
+
+    override fun RBuilder.render() {
+        sectionTitle(section)
+        p {
+            +"""
+Combine sets of button groups into button toolbars for more complex components. Use utility classes as needed to space
+out groups, buttons, and more.
+            """
+        }
+        liveExample {
+            buttonToolbar(label = "Toolbar with button groups") {
+                buttonGroup(classes = "${ClassNames.MR_2}", label = "First group") {
+                    for (x in 1..4) {
+                        Buttons.solid.secondary { +x.toString() }
+                    }
+                }
+                buttonGroup(classes = "${ClassNames.MR_2}", label = "Second group") {
+                    for (x in 5..7) {
+                        Buttons.solid.secondary { +x.toString() }
+                    }
+                }
+                buttonGroup(label = "Third group") {
+                    Buttons.solid.secondary { +"8" }
+                }
+            }
+        }
+        codeExample {
+            importButtonsBuilder()
+            import("components.button.${RBuilder::buttonGroup.name}")
+            import("components.button.${RBuilder::buttonToolbar.name}")
+            ln { }
+            ktFun(RBuilder::buttonToolbar, args = mapOf("label" to Quoted("Toolbar with button groups"))) {
+                ktFun(
+                    RBuilder::buttonGroup,
+                    args = mapOf("classes" to Quoted("\${${ClassNames.MR_2.kt}}"), "label" to Quoted("First group"))
+                ) {
+                    for (x in 1..4) {
+                        ktFun(solidSecondaryFun, solidButtonBuilderParents, style = FunStyle.INLINE_BLOCK) {
+                            string(x.toString())
+                        }
+                    }
+                }
+                ktFun(
+                    RBuilder::buttonGroup,
+                    args = mapOf("classes" to Quoted("\${${ClassNames.MR_2.kt}}"), "label" to Quoted("Second group"))
+                ) {
+                    for (x in 5..7) {
+                        ktFun(solidSecondaryFun, solidButtonBuilderParents, style = FunStyle.INLINE_BLOCK) {
+                            string(x.toString())
+                        }
+                    }
+                }
+                ktFun(
+                    RBuilder::buttonGroup,
+                    args = mapOf("label" to Quoted("Third group"))
+                ) {
+                    ktFun(solidSecondaryFun, solidButtonBuilderParents, style = FunStyle.INLINE_BLOCK) {
+                        string("8")
+                    }
+                }
+            }
+        }
+        // Todo Add Mixing with Input Groups
+    }
+}

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/Helpers.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/Helpers.kt
@@ -1,0 +1,7 @@
+package react.bootstrap.site.components.docs.components.buttongroup
+
+import react.bootstrap.site.components.docs.buildNestedName
+import react.bootstrap.components.button.ButtonGroup as ButtonGroupCmp
+
+internal val ButtonGroupCmp.Sizes.ktN
+    get() = buildNestedName(name, ButtonGroupCmp::class, this::class)

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/Reference.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/Reference.kt
@@ -1,0 +1,77 @@
+package react.bootstrap.site.components.docs.components.buttongroup
+
+import react.RBuilder
+import react.bootstrap.components.button.ButtonGroup
+import react.bootstrap.components.button.ButtonToolbar
+import react.bootstrap.components.button.buttonGroup
+import react.bootstrap.components.button.buttonToolbar
+import react.bootstrap.site.components.docs.FunReference
+import react.bootstrap.site.components.docs.buildNestedName
+import react.bootstrap.site.components.docs.components.buttons.ktN
+import react.bootstrap.site.components.docs.fixings.SectionComponent
+import react.bootstrap.site.components.docs.fixings.codeExample
+import react.dom.p
+
+internal class Reference : SectionComponent() {
+    override val title: String = "Reference"
+
+    override fun RBuilder.render() {
+        sectionTitle(section)
+        subSectionTitle(RBuilder::buttonGroup.name, section)
+        p {
+            +"Adds a button group."
+        }
+        codeExample {
+            +FunReference(
+                RBuilder::buttonGroup,
+                setOf(RBuilder::class.simpleName!!),
+                setOf(
+                    FunReference.Argument(
+                        "appearance",
+                        buildNestedName(ButtonGroup.Appearance::class, ButtonGroup::class),
+                        false,
+                        ButtonGroup.Appearance.DEFAULT.ktN
+                    ),
+                    FunReference.Argument(
+                        "behaviour",
+                        buildNestedName(ButtonGroup.Behaviours::class, ButtonGroup::class),
+                        true,
+                        FunReference.Argument.NULL
+                    ),
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
+                    FunReference.Argument("label", String::class, true, FunReference.Argument.NULL),
+                    FunReference.Argument(
+                        "sizes",
+                        buildNestedName(ButtonGroup.Sizes::class, ButtonGroup::class),
+                        true,
+                        FunReference.Argument.NULL
+                    ),
+                    FunReference.Argument(
+                        "block",
+                        "RHandler<${buildNestedName(ButtonGroup.Props::class, ButtonGroup::class)}>"
+                    )
+                ),
+                "ReactElement"
+            ).print(false)
+        }
+        subSectionTitle(RBuilder::buttonToolbar.name, section)
+        p {
+            +"Add a button toolbar."
+        }
+        codeExample {
+            +FunReference(
+                RBuilder::buttonToolbar,
+                setOf(RBuilder::class.simpleName!!),
+                setOf(
+                    FunReference.Argument("classes", String::class, true, FunReference.Argument.NULL),
+                    FunReference.Argument("label", String::class, true, FunReference.Argument.NULL),
+                    FunReference.Argument(
+                        "block",
+                        "RHandler<${buildNestedName(ButtonToolbar.Props::class, ButtonToolbar::class)}>"
+                    )
+                ),
+                "ReactElement"
+            ).print(false)
+        }
+    }
+}

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/Sizing.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/Sizing.kt
@@ -4,7 +4,9 @@ import react.RBuilder
 import react.bootstrap.components.button.ButtonGroup
 import react.bootstrap.components.button.Buttons
 import react.bootstrap.components.button.buttonGroup
-import react.bootstrap.site.components.docs.components.buttons.importButtonsBuilder
+import react.bootstrap.site.components.docs.components.importButtonGroup
+import react.bootstrap.site.components.docs.components.importButtonGroupBuilder
+import react.bootstrap.site.components.docs.components.importButtonsBuilder
 import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.Quoted
 import react.bootstrap.site.components.docs.fixings.SectionComponent
@@ -47,16 +49,9 @@ Instead of applying button sizing classes to every button in a group, just set `
             br { }
         }
         codeExample {
-            import("components.button.ButtonGroup")
+            importButtonGroup()
             importButtonsBuilder()
-            import("components.button.${RBuilder::buttonGroup.name}")
-            ln { }
-            ktFun(
-                RBuilder::buttonGroup,
-                args = mapOf("sizes" to ButtonGroup.Sizes.LG.ktN, "label" to Quoted("..."))
-            ) {
-                ln { +"..." }
-            }
+            importButtonGroupBuilder()
             ktFun(RBuilder::br, style = FunStyle.INLINE_BLOCK) { }
             ktFun(
                 RBuilder::buttonGroup,

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/Sizing.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/Sizing.kt
@@ -1,0 +1,76 @@
+package react.bootstrap.site.components.docs.components.buttongroup
+
+import react.RBuilder
+import react.bootstrap.components.button.ButtonGroup
+import react.bootstrap.components.button.Buttons
+import react.bootstrap.components.button.buttonGroup
+import react.bootstrap.site.components.docs.components.buttons.importButtonsBuilder
+import react.bootstrap.site.components.docs.fixings.FunStyle
+import react.bootstrap.site.components.docs.fixings.Quoted
+import react.bootstrap.site.components.docs.fixings.SectionComponent
+import react.bootstrap.site.components.docs.fixings.codeExample
+import react.bootstrap.site.components.docs.fixings.liveExample
+import react.bootstrap.site.external.Markdown
+import react.dom.br
+
+internal class Sizing : SectionComponent() {
+    override val title: String = "Sizing"
+
+    override fun RBuilder.render() {
+        sectionTitle(section)
+        Markdown {
+            //language=Markdown
+            +"""
+Instead of applying button sizing classes to every button in a group, just set `sizes` to each
+`${RBuilder::buttonGroup.name}`, including each one when nesting multiple groups.
+            """
+        }
+        val leftMiddleRight = listOf("Left", "Middle", "Right")
+        liveExample {
+            buttonGroup(sizes = ButtonGroup.Sizes.LG, label = "...") {
+                leftMiddleRight.forEach {
+                    Buttons.solid.secondary { +it }
+                }
+            }
+            br { }
+            buttonGroup(label = "...") {
+                leftMiddleRight.forEach {
+                    Buttons.solid.secondary { +it }
+                }
+            }
+            br { }
+            buttonGroup(sizes = ButtonGroup.Sizes.SM, label = "...") {
+                leftMiddleRight.forEach {
+                    Buttons.solid.secondary { +it }
+                }
+            }
+            br { }
+        }
+        codeExample {
+            import("components.button.ButtonGroup")
+            importButtonsBuilder()
+            import("components.button.${RBuilder::buttonGroup.name}")
+            ln { }
+            ktFun(
+                RBuilder::buttonGroup,
+                args = mapOf("sizes" to ButtonGroup.Sizes.LG.ktN, "label" to Quoted("..."))
+            ) {
+                ln { +"..." }
+            }
+            ktFun(RBuilder::br, style = FunStyle.INLINE_BLOCK) { }
+            ktFun(
+                RBuilder::buttonGroup,
+                args = mapOf("label" to Quoted("..."))
+            ) {
+                ln { +"..." }
+            }
+            ktFun(RBuilder::br, style = FunStyle.INLINE_BLOCK) { }
+            ktFun(
+                RBuilder::buttonGroup,
+                args = mapOf("sizes" to ButtonGroup.Sizes.SM.ktN, "label" to Quoted("..."))
+            ) {
+                ln { +"..." }
+            }
+        }
+    }
+}

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/VerticalVariation.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttongroup/VerticalVariation.kt
@@ -1,47 +1,48 @@
 package react.bootstrap.site.components.docs.components.buttongroup
 
 import react.RBuilder
+import react.bootstrap.components.button.ButtonGroup
 import react.bootstrap.components.button.Buttons
 import react.bootstrap.components.button.buttonGroup
-import react.bootstrap.site.components.docs.components.buttons.solidButtonBuilderParents
-import react.bootstrap.site.components.docs.components.buttons.solidSecondaryFun
+import react.bootstrap.site.components.docs.components.buttons.ktN
+import react.bootstrap.site.components.docs.components.importButtonGroup
 import react.bootstrap.site.components.docs.components.importButtonGroupBuilder
 import react.bootstrap.site.components.docs.components.importButtonsBuilder
-import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.SectionComponent
 import react.bootstrap.site.components.docs.fixings.codeExample
 import react.bootstrap.site.components.docs.fixings.liveExample
 import react.bootstrap.site.external.Markdown
 
-internal class BasicExample : SectionComponent() {
-    override val title: String = "Basic example"
+internal class VerticalVariation : SectionComponent() {
+    override val title: String = "Vertical variation"
 
     override fun RBuilder.render() {
         sectionTitle(section)
         Markdown {
             //language=Markdown
             +"""
-Wrap a series of buttons in `${RBuilder::buttonGroup.name}`.
+Make a set of buttons appear vertically stacked rather than horizontally. __Split button dropdowns are not supported
+here.__
             """
         }
-        val leftMiddleRight = listOf("Left", "Middle", "Right")
         liveExample {
-            buttonGroup {
-                leftMiddleRight.forEach {
-                    Buttons.solid.secondary { +it }
+            buttonGroup(ButtonGroup.Appearance.VERTICAL) {
+                for (x in 1..6) {
+                    Buttons.solid.secondary { +"Button" }
                 }
             }
         }
+        // Todo add second liveExample featuring Dropdowns
         codeExample {
+            importButtonGroup()
             importButtonsBuilder()
             importButtonGroupBuilder()
             ln { }
-            ktFun(RBuilder::buttonGroup) {
-                leftMiddleRight.forEach {
-                    ktFun(solidSecondaryFun, solidButtonBuilderParents, style = FunStyle.INLINE_BLOCK) {
-                        string(it)
-                    }
-                }
+            ktFun(
+                RBuilder::buttonGroup,
+                args = mapOf(null to ButtonGroup.Appearance.VERTICAL.ktN)
+            ) {
+                ln { +"..." }
             }
         }
     }

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/ActiveState.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/ActiveState.kt
@@ -152,6 +152,7 @@ When wrapped in a `buttonGroup` a bunch of buttons can behave like radio- or che
         codeExample {
             importButton()
             importButtonsBuilder()
+            import("components.button.${RBuilder::buttonGroup.name}")
             ln { }
             ktFun(RBuilder::buttonGroup, args = mapOf(null to ButtonGroup.Behaviours.RADIOS.ktN)) {
                 for (x in 1..3) {
@@ -236,6 +237,7 @@ can set `${ButtonGroup.Props::renderAsGroup.name}` to `false`.
         codeExample {
             importButton()
             importButtonsBuilder()
+            import("components.button.${RBuilder::buttonGroup.name}")
             ln { }
             ktFun(RBuilder::buttonGroup, args = mapOf("renderAsGroup" to false)) {
                 for (x in 1..6) {

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/ActiveState.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/ActiveState.kt
@@ -9,6 +9,9 @@ import react.bootstrap.components.button.Button
 import react.bootstrap.components.button.ButtonGroup
 import react.bootstrap.components.button.Buttons
 import react.bootstrap.components.button.buttonGroup
+import react.bootstrap.site.components.docs.components.importButtonGroup
+import react.bootstrap.site.components.docs.components.importButtonGroupBuilder
+import react.bootstrap.site.components.docs.components.importButtonsBuilder
 import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.Quoted
 import react.bootstrap.site.components.docs.fixings.SectionComponent
@@ -127,7 +130,7 @@ When wrapped in a `buttonGroup` a bunch of buttons can behave like radio- or che
             """
         }
         liveExample {
-            buttonGroup(ButtonGroup.Behaviours.RADIOS) {
+            buttonGroup(behaviour = ButtonGroup.Behaviours.RADIOS) {
                 for (x in 1..3) {
                     Buttons.solid.secondary(active = x == 1) {
                         attrs {
@@ -138,7 +141,7 @@ When wrapped in a `buttonGroup` a bunch of buttons can behave like radio- or che
                 }
             }
             br { }
-            buttonGroup(ButtonGroup.Behaviours.CHECKBOXES) {
+            buttonGroup(behaviour = ButtonGroup.Behaviours.CHECKBOXES) {
                 for (x in 1..3) {
                     Buttons.solid.secondary {
                         attrs {
@@ -151,10 +154,11 @@ When wrapped in a `buttonGroup` a bunch of buttons can behave like radio- or che
         }
         codeExample {
             importButton()
+            importButtonGroup()
             importButtonsBuilder()
-            import("components.button.${RBuilder::buttonGroup.name}")
+            importButtonGroupBuilder()
             ln { }
-            ktFun(RBuilder::buttonGroup, args = mapOf(null to ButtonGroup.Behaviours.RADIOS.ktN)) {
+            ktFun(RBuilder::buttonGroup, args = mapOf("behaviour" to ButtonGroup.Behaviours.RADIOS.ktN)) {
                 for (x in 1..3) {
                     val args = if (x == 1) {
                         mapOf<String?, Any>("active" to true)
@@ -181,7 +185,7 @@ When wrapped in a `buttonGroup` a bunch of buttons can behave like radio- or che
                 }
             }
             ktFun(RBuilder::br, style = FunStyle.INLINE)
-            ktFun(RBuilder::buttonGroup, args = mapOf(null to ButtonGroup.Behaviours.CHECKBOXES.ktN)) {
+            ktFun(RBuilder::buttonGroup, args = mapOf("behaviour" to ButtonGroup.Behaviours.CHECKBOXES.ktN)) {
                 for (x in 1..3) {
                     ktFun(solidSecondaryFun, solidButtonBuilderParents) {
                         ktFun(RElementBuilder<RProps>::attrs) {
@@ -207,11 +211,11 @@ When wrapped in a `buttonGroup` a bunch of buttons can behave like radio- or che
             //language=Markdown
             +"""
 Or you use actual checkboxes and radios and display them as buttons. If you do not like the looks of a `buttonGroup` you
-can set `${ButtonGroup.Props::renderAsGroup.name}` to `false`.
+can set `${ButtonGroup.Props::appearance.name}` to `${ButtonGroup.Appearance.NONE.ktN}`.
             """
         }
         liveExample {
-            buttonGroup(renderAsGroup = false) {
+            buttonGroup(appearance = ButtonGroup.Appearance.NONE) {
                 for (x in 1..6) {
                     if (x % 2 == 0) {
                         Buttons.solid.secondary(
@@ -236,10 +240,11 @@ can set `${ButtonGroup.Props::renderAsGroup.name}` to `false`.
         }
         codeExample {
             importButton()
+            importButtonGroup()
             importButtonsBuilder()
-            import("components.button.${RBuilder::buttonGroup.name}")
+            importButtonGroupBuilder()
             ln { }
-            ktFun(RBuilder::buttonGroup, args = mapOf("renderAsGroup" to false)) {
+            ktFun(RBuilder::buttonGroup, args = mapOf("appearance" to ButtonGroup.Appearance.NONE.ktN)) {
                 for (x in 1..6) {
                     if (x % 2 == 0) {
                         ktFun(

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/ButtonTags.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/ButtonTags.kt
@@ -5,6 +5,7 @@ import react.RBuilder
 import react.bootstrap.components.button.Button
 import react.bootstrap.components.button.Buttons
 import react.bootstrap.site.components.docs.buildNestedName
+import react.bootstrap.site.components.docs.components.importButtonsBuilder
 import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.Quoted
 import react.bootstrap.site.components.docs.fixings.SectionComponent

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/DisabledState.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/DisabledState.kt
@@ -3,6 +3,7 @@ package react.bootstrap.site.components.docs.components.buttons
 import react.RBuilder
 import react.bootstrap.components.button.Button
 import react.bootstrap.components.button.Buttons
+import react.bootstrap.site.components.docs.components.importButtonsBuilder
 import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.Quoted
 import react.bootstrap.site.components.docs.fixings.SectionComponent

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Examples.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Examples.kt
@@ -3,6 +3,7 @@ package react.bootstrap.site.components.docs.components.buttons
 import react.RBuilder
 import react.bootstrap.components.button.Button
 import react.bootstrap.components.button.Buttons
+import react.bootstrap.site.components.docs.components.importButtonsBuilder
 import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.SectionComponent
 import react.bootstrap.site.components.docs.fixings.codeExample

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Helpers.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Helpers.kt
@@ -11,7 +11,6 @@ import react.bootstrap.components.button.Button.Variants
 import react.bootstrap.components.button.Button.Variants.Outline
 import react.bootstrap.components.button.ButtonGroup
 import react.bootstrap.components.button.Buttons
-import react.bootstrap.components.button.buttonGroup
 import react.bootstrap.site.components.docs.buildNestedName
 import react.bootstrap.site.components.docs.fixings.CodeExampleBuilder
 import kotlin.reflect.KClass

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Helpers.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Helpers.kt
@@ -11,6 +11,7 @@ import react.bootstrap.components.button.Button.Variants
 import react.bootstrap.components.button.Button.Variants.Outline
 import react.bootstrap.components.button.ButtonGroup
 import react.bootstrap.components.button.Buttons
+import react.bootstrap.components.button.buttonGroup
 import react.bootstrap.site.components.docs.buildNestedName
 import react.bootstrap.site.components.docs.fixings.CodeExampleBuilder
 import kotlin.reflect.KClass
@@ -38,6 +39,9 @@ internal val Button.Types.Input.Type.ktN
     get() = buildNestedName(name, Button::class, Button.Types::class, Button.Types.Input::class)
 
 internal val ButtonGroup.Behaviours.ktN
+    get() = buildNestedName(name, ButtonGroup::class, this::class)
+
+internal val ButtonGroup.Appearance.ktN
     get() = buildNestedName(name, ButtonGroup::class, this::class)
 
 internal val RBuilder.solidButtonBuilderParents
@@ -83,10 +87,6 @@ internal val RBuilder.solidWarningFun: ButtonFun
 internal val RBuilder.outlineWarningFun: ButtonFun
     get() = Buttons.outline::warning
 
-internal fun CodeExampleBuilder.importButtonsBuilder() {
-    import(buildNestedName(RBuilder::Buttons.name, "button", "components"))
-}
-
 internal fun CodeExampleBuilder.importButton() {
-    import(buildNestedName(Button::class.simpleName!!, "button", "components"))
+    import(buildNestedName(Button::class.simpleName!!, "components", "button"))
 }

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/OutlineButtons.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/OutlineButtons.kt
@@ -3,6 +3,7 @@ package react.bootstrap.site.components.docs.components.buttons
 import react.RBuilder
 import react.bootstrap.components.button.Button
 import react.bootstrap.components.button.Buttons
+import react.bootstrap.site.components.docs.components.importButtonsBuilder
 import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.SectionComponent
 import react.bootstrap.site.components.docs.fixings.codeExample

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Reference.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Reference.kt
@@ -18,6 +18,7 @@ internal class Reference : SectionComponent() {
     override val title: String = "Reference"
 
     override fun RBuilder.render() {
+        sectionTitle(section)
         mapOf(
             Button.Variants.Solid.DANGER to (solidDangerFun to outlineDangerFun),
             Button.Variants.Solid.DARK to (solidDarkFun to outlineDarkFun),
@@ -48,49 +49,49 @@ internal class Reference : SectionComponent() {
                     "buttonFormEncType",
                     ButtonFormEncType::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "buttonFormMethod",
                     ButtonFormMethod::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "active",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "disabled",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "nowrap",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "sizes",
                     Button.Sizes::class.nestedName,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "blockSized",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "classes",
                     String::class,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "block",
@@ -129,43 +130,43 @@ internal class Reference : SectionComponent() {
                     "target",
                     String::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "active",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "disabled",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "nowrap",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "sizes",
                     Button.Sizes::class.nestedName,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "blockSized",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "classes",
                     String::class,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "block",
@@ -202,13 +203,13 @@ internal class Reference : SectionComponent() {
                     "name",
                     String::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "title",
                     String::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "type",
@@ -220,49 +221,49 @@ internal class Reference : SectionComponent() {
                     "inputFormEncType",
                     InputFormEncType::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "inputFormMethod",
                     InputFormMethod::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "active",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "disabled",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "nowrap",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "sizes",
                     Button.Sizes::class.nestedName,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "blockSized",
                     Boolean::class.simpleName!!,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "classes",
                     String::class,
                     true,
-                    "null"
+                    FunReference.Argument.NULL
                 ),
                 FunReference.Argument(
                     "block",

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Sizes.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/components/buttons/Sizes.kt
@@ -3,6 +3,7 @@ package react.bootstrap.site.components.docs.components.buttons
 import react.RBuilder
 import react.bootstrap.components.button.Button.Sizes
 import react.bootstrap.components.button.Buttons
+import react.bootstrap.site.components.docs.components.importButtonsBuilder
 import react.bootstrap.site.components.docs.fixings.FunStyle
 import react.bootstrap.site.components.docs.fixings.SectionComponent
 import react.bootstrap.site.components.docs.fixings.codeExample

--- a/site/src/main/kotlin/react/bootstrap/site/components/docs/content/typography/Headings.kt
+++ b/site/src/main/kotlin/react/bootstrap/site/components/docs/content/typography/Headings.kt
@@ -56,7 +56,7 @@ heading but cannot use the associated HTML element.
                 RBuilder::h4,
                 RBuilder::h5,
                 RBuilder::h6
-            ).forEachIndexed() { index, function ->
+            ).forEachIndexed { index, function ->
                 ktFun(function, style = FunStyle.INLINE_BLOCK, args = mapOf(null to "RBuilder::p")) {
                     string("h${index + 1}. Bootstrap heading")
                 }

--- a/src/main/kotlin/react/bootstrap/components/button/Builder.kt
+++ b/src/main/kotlin/react/bootstrap/components/button/Builder.kt
@@ -842,6 +842,7 @@ fun RBuilder.buttonGroup(
     label: String? = null,
     classes: String? = null,
     renderAsGroup: Boolean = true,
+    sizes: ButtonGroup.Sizes? = null,
     block: RHandler<ButtonGroup.Props>
 ): ReactElement {
     val builder = RElementBuilder<ButtonGroup.Props>(jsObject())
@@ -877,7 +878,22 @@ fun RBuilder.buttonGroup(
             this.className = classes
             this.buttons = buttons
             this.renderAsGroup = renderAsGroup
+            this.sizes = sizes
         }
         block()
     }
 }
+
+fun RBuilder.buttonToolbar(
+    classes: String? = null,
+    label: String? = null,
+    block: RHandler<ButtonToolbar.Props>
+): ReactElement =
+    child(ButtonToolbar::class) {
+        attrs {
+            className = classes
+            ariaLabel = label
+        }
+
+        block()
+    }

--- a/src/main/kotlin/react/bootstrap/components/button/Builder.kt
+++ b/src/main/kotlin/react/bootstrap/components/button/Builder.kt
@@ -838,10 +838,10 @@ val RBuilder.Buttons
     get() = ButtonBuilder(this)
 
 fun RBuilder.buttonGroup(
+    appearance: ButtonGroup.Appearance = ButtonGroup.Appearance.DEFAULT,
     behaviour: ButtonGroup.Behaviours? = null,
-    label: String? = null,
     classes: String? = null,
-    renderAsGroup: Boolean = true,
+    label: String? = null,
     sizes: ButtonGroup.Sizes? = null,
     block: RHandler<ButtonGroup.Props>
 ): ReactElement {
@@ -873,11 +873,11 @@ fun RBuilder.buttonGroup(
 
     return child(ButtonGroup::class) {
         attrs {
+            this.appearance = appearance
             this.behaviour = behaviour
-            this.label = label
-            this.className = classes
             this.buttons = buttons
-            this.renderAsGroup = renderAsGroup
+            this.className = classes
+            this.label = label
             this.sizes = sizes
         }
         block()

--- a/src/main/kotlin/react/bootstrap/components/button/ButtonGroup.kt
+++ b/src/main/kotlin/react/bootstrap/components/button/ButtonGroup.kt
@@ -115,8 +115,12 @@ class ButtonGroup(props: Props) : RComponent<ButtonGroup.Props, ButtonGroup.Stat
     override fun RBuilder.render() {
         val btnGroupClasses = mutableSetOf<ClassNames>()
 
-        if (props.renderAsGroup == true) {
+        if (props.appearance == Appearance.DEFAULT || props.appearance == null) {
             btnGroupClasses.add(ClassNames.BTN_GROUP)
+        }
+
+        if (props.appearance == Appearance.VERTICAL) {
+            btnGroupClasses.add(ClassNames.BTN_GROUP_VERTICAL)
         }
 
         props.sizes?.also {
@@ -180,15 +184,21 @@ class ButtonGroup(props: Props) : RComponent<ButtonGroup.Props, ButtonGroup.Stat
     }
 
     interface Props : WithClassName {
-        var label: String?
+        var appearance: Appearance?
         var behaviour: Behaviours?
         var buttons: Map<Int, Button.Props>?
-        var renderAsGroup: Boolean? // todo add change to enum with: DEFAULT, NO_GROUP, VERTICAL
+        var label: String?
         var sizes: Sizes?
     }
 
     interface State : RState {
         var activeButtons: Collection<Int>?
+    }
+
+    enum class Appearance {
+        DEFAULT,
+        NONE,
+        VERTICAL
     }
 
     enum class Behaviours {

--- a/src/main/kotlin/react/bootstrap/components/button/ButtonGroup.kt
+++ b/src/main/kotlin/react/bootstrap/components/button/ButtonGroup.kt
@@ -11,6 +11,7 @@ import react.RComponent
 import react.RState
 import react.ReactElement
 import react.bootstrap.appendClass
+import react.bootstrap.lib.ClassNameEnum
 import react.bootstrap.lib.ClassNames
 import react.bootstrap.lib.EventHandler
 import react.bootstrap.lib.WithTypeFlag
@@ -112,11 +113,22 @@ class ButtonGroup(props: Props) : RComponent<ButtonGroup.Props, ButtonGroup.Stat
     }
 
     override fun RBuilder.render() {
-        val classes = if (props.renderAsGroup == true) {
-            props.className.appendClass(ClassNames.BTN_GROUP)
-        } else {
-            props.className
+        val btnGroupClasses = mutableSetOf<ClassNames>()
+
+        if (props.renderAsGroup == true) {
+            btnGroupClasses.add(ClassNames.BTN_GROUP)
         }
+
+        props.sizes?.also {
+            btnGroupClasses.add(
+                when (it) {
+                    Sizes.SM -> ClassNames.BTN_GROUP_SM
+                    Sizes.LG -> ClassNames.BTN_GROUP_LG
+                }
+            )
+        }
+
+        val classes = props.className.appendClass(btnGroupClasses)
 
         div(classes = classes) {
             attrs {
@@ -171,7 +183,8 @@ class ButtonGroup(props: Props) : RComponent<ButtonGroup.Props, ButtonGroup.Stat
         var label: String?
         var behaviour: Behaviours?
         var buttons: Map<Int, Button.Props>?
-        var renderAsGroup: Boolean?
+        var renderAsGroup: Boolean? // todo add change to enum with: DEFAULT, NO_GROUP, VERTICAL
+        var sizes: Sizes?
     }
 
     interface State : RState {
@@ -181,5 +194,10 @@ class ButtonGroup(props: Props) : RComponent<ButtonGroup.Props, ButtonGroup.Stat
     enum class Behaviours {
         CHECKBOXES,
         RADIOS;
+    }
+
+    enum class Sizes(override val className: ClassNames) : ClassNameEnum {
+        SM(ClassNames.BTN_GROUP_SM),
+        LG(ClassNames.BTN_GROUP_LG);
     }
 }

--- a/src/main/kotlin/react/bootstrap/components/button/ButtonToolbar.kt
+++ b/src/main/kotlin/react/bootstrap/components/button/ButtonToolbar.kt
@@ -1,0 +1,29 @@
+package react.bootstrap.components.button
+
+import kotlinx.html.role
+import react.RBuilder
+import react.RComponent
+import react.RState
+import react.bootstrap.appendClass
+import react.bootstrap.lib.ClassNames
+import react.bootstrap.lib.WithAriaLabel
+import react.bootstrap.lib.ariaLabel
+import react.dom.WithClassName
+import react.dom.div
+
+class ButtonToolbar : RComponent<ButtonToolbar.Props, RState>() {
+    override fun RBuilder.render() {
+        div(classes = props.className.appendClass(ClassNames.BTN_TOOLBAR)) {
+            attrs {
+                role = "toolbar"
+
+                props.ariaLabel?.let {
+                    ariaLabel = it
+                }
+            }
+            children()
+        }
+    }
+
+    interface Props : WithClassName, WithAriaLabel
+}

--- a/src/main/kotlin/react/bootstrap/lib/RProps.kt
+++ b/src/main/kotlin/react/bootstrap/lib/RProps.kt
@@ -19,6 +19,10 @@ interface WithRHandlerBlock<T : RProps> : RProps {
     var handler: RHandler<T>
 }
 
+interface WithAriaLabel : RProps {
+    var ariaLabel: String?
+}
+
 interface WithDomEvents : RProps {
     var onAbort: EventHandler?
     var onAnimationEnd: EventHandler?


### PR DESCRIPTION
Almost done.

Todo:

- [x] Change `renderAsGroup` into an enum to also handle vertical group look
- [x] Reference